### PR TITLE
Handle protos values in client

### DIFF
--- a/PyADRL/envs/ngw_env.py
+++ b/PyADRL/envs/ngw_env.py
@@ -11,7 +11,10 @@ from ..ngw.v1.ngw2d_pb2 import (
     DoStepRequest,
 )
 from ..utils.ngw2d_actions import get_action
-from ..utils.ngw2d_client import NGWClient
+from ..utils.ngw2d_client import (
+    NGWClient,
+    State,
+)
 from .reward_functions.rewards import RewardFunction
 from .map_configs.map_config import MapConfig
 from ..logger.metricslogger import EpisodeOutcome
@@ -107,7 +110,7 @@ class NGWEnvironment(ParallelEnv):
         self.timestep = 0
 
         if self.id is None:
-            response = self.client.New(
+            state = self.client.New(
                 NewRequest(
                     map=self.map_config.get_map_spec(),
                     evader_count=self.n_evaders,
@@ -115,17 +118,9 @@ class NGWEnvironment(ParallelEnv):
                     drone_velocity=self.drone_velocity,
                 )
             )
-            if response.state_response.WhichOneof("state_or_error") == "state":
-                state = response.state_response.state
-                self.id = state.sim_id
-            else:
-                raise ValueError("Error in new request")
+            self.id = state.sim_id
         else:
-            response = self.client.Reset(ResetRequest(sim_id=self.id))
-            if response.state_response.WhichOneof("state_or_error") == "state":
-                state = response.state_response.state
-            else:
-                raise ValueError("Error in reset request")
+            state = self.client.Reset(ResetRequest(sim_id=self.id))
 
         for drone_state in state.drone_states:
             is_evader = drone_state.is_evader
@@ -171,7 +166,7 @@ class NGWEnvironment(ParallelEnv):
                         )
                     )
 
-        response = self.client.DoStep(
+        state = self.client.DoStep(
             DoStepRequest(sim_id=self.id, drone_actions=actions_send)
         )
 
@@ -180,25 +175,20 @@ class NGWEnvironment(ParallelEnv):
         terminations["__all__"] = False
         truncations["__all__"] = False
 
-        state = None
-        if response.state_response.WhichOneof("state_or_error") == "state":
-            state = response.state_response.state
-            for drone_state in state.drone_states:
-                key = EVADERS if drone_state.is_evader else PURSUERS
-                # Mark destroyed drones as destroyed in python
-                if drone_state.destroyed:
-                    for drone in self.drones[key]:
-                        if drone_state.id == drone.id:
-                            drone.destroyed = True
-                            terminations[drone.name] = True
-                            break
-                else:  # Update positions
-                    for drone in self.drones[key]:
-                        if drone_state.id == drone.id:
-                            drone.x = drone_state.x
-                            drone.y = drone_state.y
-        else:
-            raise ValueError("Recieved error from DoStepRequest")
+        for drone_state in state.drone_states:
+            key = EVADERS if drone_state.is_evader else PURSUERS
+            # Mark destroyed drones as destroyed in python
+            if drone_state.destroyed:
+                for drone in self.drones[key]:
+                    if drone_state.id == drone.id:
+                        drone.destroyed = True
+                        terminations[drone.name] = True
+                        break
+            else:  # Update positions
+                for drone in self.drones[key]:
+                    if drone_state.id == drone.id:
+                        drone.x = drone_state.x
+                        drone.y = drone_state.y
 
         outcome = EpisodeOutcome(episode_length=self.timestep + 1)
 
@@ -228,7 +218,7 @@ class NGWEnvironment(ParallelEnv):
                 "breached": 1.0 if outcome.breached else 0.0,
                 "capture_step": float(outcome.capture_step)
                 if outcome.capture_step is not None
-                else 100.0,  # What is this?
+                else 100.0,
                 "episode_length": float(outcome.episode_length),
             }
             for a in self.agents:

--- a/PyADRL/envs/ngw_env.py
+++ b/PyADRL/envs/ngw_env.py
@@ -11,10 +11,7 @@ from ..ngw.v1.ngw2d_pb2 import (
     DoStepRequest,
 )
 from ..utils.ngw2d_actions import get_action
-from ..utils.ngw2d_client import (
-    NGWClient,
-    State,
-)
+from ..utils.ngw2d_client import NGWClient
 from .reward_functions.rewards import RewardFunction
 from .map_configs.map_config import MapConfig
 from ..logger.metricslogger import EpisodeOutcome

--- a/PyADRL/envs/reward_functions/grid_world_rewards.py
+++ b/PyADRL/envs/reward_functions/grid_world_rewards.py
@@ -1,7 +1,7 @@
 from .rewards import RewardFunction
 from ..ngw_drone import NGW_Drone
 from ..map_configs.map_config import MapConfig
-from ...ngw.v1.ngw2d_pb2 import State
+from ...utils.ngw2d_client import State, EventTypes
 from ...utils.chebeshyv import chebyshev_distance
 
 
@@ -42,19 +42,17 @@ class GridWorldRewards(RewardFunction):
         }
 
         # distribute rewards for events that occured
-        for event in new_state.events:
-            which_one = event.WhichOneof("event_oneof")
-            match which_one:
-                case "target_reached_event ":
-                    ids = [d for d in event.target_reached_event.drone_ids]
-                    for id in ids:
+        for event_type, event_occurances in new_state.events.items():
+            flat_drone_ids = [id for drone_ids in event_occurances for id in drone_ids]
+            match event_type:
+                case EventTypes.TargetReachedEvent:
+                    for id in flat_drone_ids:
                         d = all_drones[id]
                         if d is None:
                             raise Exception(f"Drone with id {id} not found")
                         rewards[d.name] += self.REWARD_EVADER_TARGET_REACHED
-                case "out_of_bounds_event ":
-                    ids = [d for d in event.out_of_bounds_event.drone_ids]
-                    for id in ids:
+                case EventTypes.OutOfBoundsEvent:
+                    for id in flat_drone_ids:
                         d = all_drones[id]
                         if d is None:
                             raise Exception(f"Drone with id {id} not found")
@@ -62,9 +60,8 @@ class GridWorldRewards(RewardFunction):
                             rewards[d.name] += self.REWARD_EVADER_OUT_OF_BOUNDS
                         else:
                             rewards[d.name] += self.REWARD_PURSUER_OUT_OF_BOUNDS
-                case "collision_event ":
-                    ids = [d for d in event.collision_event.drone_ids]
-                    for id in ids:
+                case EventTypes.CollisionEvent:
+                    for id in flat_drone_ids:
                         d = all_drones[id]
                         if d is None:
                             raise Exception(f"Drone with id {id} not found")
@@ -72,6 +69,22 @@ class GridWorldRewards(RewardFunction):
                             rewards[d.name] += self.REWARD_EVADER_DESTROYED
                         else:
                             rewards[d.name] += self.REWARD_PURSUER_DESTROYED
+                case EventTypes.CaptureEvent:
+                    for id in flat_drone_ids:
+                        d = all_drones[id]
+                        if d is None:
+                            raise Exception(f"Drone with id {id} not found")
+                        if d.is_evader:
+                            rewards[d.name] += self.REWARD_EVADER_CAUGHT
+                        else:
+                            rewards[d.name] += self.REWARD_PURSUER_CAUGHT_EVADER_SELF
+                    other_pursuers = [
+                        d
+                        for d in drones["pursuers"]
+                        if d.id not in flat_drone_ids and not d.destroyed
+                    ]
+                    for p in other_pursuers:
+                        rewards[p.name] += self.REWARD_PURSUER_CAUGHT_EVADER_OTHERS
 
         for drone in all_drones.values():
             if drone.is_evader:
@@ -79,6 +92,7 @@ class GridWorldRewards(RewardFunction):
                 distance_to_pursuer = min(
                     chebyshev_distance(drone.x, drone.y, pursuer.x, pursuer.y)
                     for pursuer in drones["pursuers"]
+                    if not pursuer.destroyed
                 )
                 rewards[drone.name] += (
                     distance_to_pursuer * self.REWARD_EVADER_FAR_FROM_PUSUERS
@@ -94,6 +108,7 @@ class GridWorldRewards(RewardFunction):
                 distance_to_evader = min(
                     chebyshev_distance(drone.x, drone.y, evader.x, evader.y)
                     for evader in drones["evaders"]
+                    if not evader.destroyed
                 )
                 rewards[drone.name] += (
                     distance_to_evader * self.REWARD_PURSUER_FAR_FROM_EVADER

--- a/PyADRL/envs/reward_functions/grid_world_rewards.py
+++ b/PyADRL/envs/reward_functions/grid_world_rewards.py
@@ -43,19 +43,22 @@ class GridWorldRewards(RewardFunction):
 
         # distribute rewards for events that occured
         for event_type, event_occurances in new_state.events.items():
-            flat_drone_ids = [id for drone_ids in event_occurances for id in drone_ids]
+            flat_drone_ids = []
+            for drone_ids in event_occurances:
+                for id in drone_ids:
+                    if id not in all_drones:
+                        continue  # TODO: remove this when events are fixed
+                        # raise ValueError(f"Terminated agent with id {id} recieved from {event_type} event")
+                    flat_drone_ids.append(id)
+
             match event_type:
                 case EventTypes.TargetReachedEvent:
                     for id in flat_drone_ids:
                         d = all_drones[id]
-                        if d is None:
-                            raise Exception(f"Drone with id {id} not found")
                         rewards[d.name] += self.REWARD_EVADER_TARGET_REACHED
                 case EventTypes.OutOfBoundsEvent:
                     for id in flat_drone_ids:
                         d = all_drones[id]
-                        if d is None:
-                            raise Exception(f"Drone with id {id} not found")
                         if d.is_evader:
                             rewards[d.name] += self.REWARD_EVADER_OUT_OF_BOUNDS
                         else:
@@ -63,8 +66,6 @@ class GridWorldRewards(RewardFunction):
                 case EventTypes.CollisionEvent:
                     for id in flat_drone_ids:
                         d = all_drones[id]
-                        if d is None:
-                            raise Exception(f"Drone with id {id} not found")
                         if d.is_evader:
                             rewards[d.name] += self.REWARD_EVADER_DESTROYED
                         else:
@@ -72,8 +73,6 @@ class GridWorldRewards(RewardFunction):
                 case EventTypes.CaptureEvent:
                     for id in flat_drone_ids:
                         d = all_drones[id]
-                        if d is None:
-                            raise Exception(f"Drone with id {id} not found")
                         if d.is_evader:
                             rewards[d.name] += self.REWARD_EVADER_CAUGHT
                         else:
@@ -90,9 +89,12 @@ class GridWorldRewards(RewardFunction):
             if drone.is_evader:
                 # reward the evader for being far from the pursuers to encourage it to move away from the pursuers
                 distance_to_pursuer = min(
-                    chebyshev_distance(drone.x, drone.y, pursuer.x, pursuer.y)
-                    for pursuer in drones["pursuers"]
-                    if not pursuer.destroyed
+                    (
+                        chebyshev_distance(drone.x, drone.y, pursuer.x, pursuer.y)
+                        for pursuer in drones["pursuers"]
+                        if not pursuer.destroyed
+                    ),
+                    default=0,
                 )
                 rewards[drone.name] += (
                     distance_to_pursuer * self.REWARD_EVADER_FAR_FROM_PUSUERS
@@ -106,9 +108,12 @@ class GridWorldRewards(RewardFunction):
             else:
                 # punish the pursuers for being far from the evader to encourage them to move towards the evader
                 distance_to_evader = min(
-                    chebyshev_distance(drone.x, drone.y, evader.x, evader.y)
-                    for evader in drones["evaders"]
-                    if not evader.destroyed
+                    (
+                        chebyshev_distance(drone.x, drone.y, evader.x, evader.y)
+                        for evader in drones["evaders"]
+                        if not evader.destroyed
+                    ),
+                    default=0,
                 )
                 rewards[drone.name] += (
                     distance_to_evader * self.REWARD_PURSUER_FAR_FROM_EVADER
@@ -120,5 +125,4 @@ class GridWorldRewards(RewardFunction):
                     rewards[drone.name] += self.REWARD_EVADER_MAX_TIMESTEPS
                 else:
                     rewards[drone.name] += self.REWARD_PURSUER_MAX_TIMESTEPS
-
         return rewards

--- a/PyADRL/envs/reward_functions/grid_world_rewards.py
+++ b/PyADRL/envs/reward_functions/grid_world_rewards.py
@@ -85,6 +85,8 @@ class GridWorldRewards(RewardFunction):
                     ]
                     for p in other_pursuers:
                         rewards[p.name] += self.REWARD_PURSUER_CAUGHT_EVADER_OTHERS
+                case EventTypes.PursuerEnteredTargetEvent:
+                    pass
 
         for drone in all_drones.values():
             if drone.is_evader:

--- a/PyADRL/envs/reward_functions/grid_world_rewards.py
+++ b/PyADRL/envs/reward_functions/grid_world_rewards.py
@@ -47,8 +47,9 @@ class GridWorldRewards(RewardFunction):
             for drone_ids in event_occurances:
                 for id in drone_ids:
                     if id not in all_drones:
-                        continue  # TODO: remove this when events are fixed
-                        # raise ValueError(f"Terminated agent with id {id} recieved from {event_type} event")
+                        raise ValueError(
+                            f"Terminated agent with id {id} recieved from {event_type}"
+                        )
                     flat_drone_ids.append(id)
 
             match event_type:

--- a/PyADRL/envs/reward_functions/rewards.py
+++ b/PyADRL/envs/reward_functions/rewards.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from ...ngw.v1.ngw2d_pb2 import State
+from ...utils.ngw2d_client import State
 from ..ngw_drone import NGW_Drone
 from ..map_configs.map_config import MapConfig
 

--- a/PyADRL/utils/ngw2d_client.py
+++ b/PyADRL/utils/ngw2d_client.py
@@ -2,18 +2,118 @@ import grpc
 from ..ngw.v1 import ngw2d_pb2, ngw2d_pb2_grpc
 
 
+class EventTypes:
+    CollisionEvent = 1
+    TargetReachedEvent = 2
+    OutOfBoundsEvent = 3
+    CaptureEvent = 4
+
+
+class DroneState:
+    def __init__(
+        self,
+        id: int,
+        x: int,
+        y: int,
+        destroyed: bool = False,
+        is_evader: bool = False,
+    ):
+        self.id = id
+        self.x = x
+        self.y = y
+        self.destroyed = destroyed
+        self.is_evader = is_evader
+
+
+class State:
+    def __init__(
+        self,
+        sim_id: int | None = None,
+        terminated: bool = False,
+        drone_states: list[DroneState] = [],
+        events: dict[EventTypes, list[list[int]]] = {},
+    ):
+        self.sim_id = sim_id
+        self.terminated = terminated
+        self.drone_states = drone_states
+        self.events = events
+
+
 class NGWClient:
     def __init__(self, channel: grpc.Channel):
         self.stub = ngw2d_pb2_grpc.SimulationServiceStub(channel)
 
-    def Reset(self, request: ngw2d_pb2.ResetRequest) -> ngw2d_pb2.ResetResponse:
-        return self.stub.Reset(request)
+    def Reset(self, request: ngw2d_pb2.ResetRequest) -> State:
+        reset_response = self.stub.Reset(request).state_response
+        if reset_response.WhichOneof("state_or_error") == "state":
+            return self.ReadState(reset_response.state)
+        else:
+            raise ValueError(
+                f"Reset request responded with an error: {reset_response.error_message}"
+            )
 
-    def DoStep(self, request: ngw2d_pb2.DoStepRequest) -> ngw2d_pb2.DoStepResponse:
-        return self.stub.DoStep(request)
+    def DoStep(self, request: ngw2d_pb2.DoStepRequest) -> State:
+        do_step_response = self.stub.DoStep(request).state_response
+        if do_step_response.WhichOneof("state_or_error") == "state":
+            return self.ReadState(do_step_response.state)
+        else:
+            raise ValueError(
+                f"DoStep request responded with an error: {do_step_response.error_message}"
+            )
 
-    def New(self, request: ngw2d_pb2.NewRequest) -> ngw2d_pb2.NewResponse:
-        return self.stub.New(request)
+    def New(self, request: ngw2d_pb2.NewRequest) -> State:
+        new_response = self.stub.New(request).state_response
+        if new_response.WhichOneof("state_or_error") == "state":
+            return self.ReadState(new_response.state)
+        else:
+            raise ValueError(
+                f"New request responded with an error: {new_response.error_message}"
+            )
 
-    def Close(self, request: ngw2d_pb2.CloseRequest) -> ngw2d_pb2.CloseResponse:
-        return self.stub.Close(request)
+    def Close(self, request: ngw2d_pb2.CloseRequest) -> None:
+        close_response = self.stub.Close(request)
+        if close_response.has_error_message():
+            raise ValueError(
+                f"Close request responded with an error: {close_response.error_message}"
+            )
+
+    def ReadState(self, state: ngw2d_pb2.State) -> State:
+        sim_id = state.sim_id
+        terminated = state.terminated
+        drone_states = [
+            DroneState(ds.id, ds.x, ds.y, ds.destroyed, ds.is_evader)
+            for ds in state.drone_states
+        ]
+
+        # Used to determine if a collision was a capture
+        ids = {
+            "evaders": [d.id for d in drone_states if d.is_evader],
+            "pursuers": [d.id for d in drone_states if not d.is_evader],
+        }
+
+        events = {}
+        for e in state.events:
+            drone_ids = []
+            event_type = None
+            match e.WhichOneof("event_oneof"):
+                case "target_reached_event":
+                    drone_ids = e.target_reached_event.drone_ids
+                    event_type = EventTypes.TargetReachedEvent
+                case "out_of_bounds_event":
+                    drone_ids = e.out_of_bounds_event.drone_ids
+                    event_type = EventTypes.OutOfBoundsEvent
+                case "collision_event":
+                    drone_ids = e.collision_event.drone_ids
+                    # Determine if it was a collision or a capture
+                    has_evader = any(d in ids["evaders"] for d in drone_ids)
+                    has_pursuer = any(d in ids["pursuers"] for d in drone_ids)
+                    event_type = (
+                        EventTypes.CaptureEvent
+                        if has_evader and has_pursuer
+                        else EventTypes.CollisionEvent
+                    )
+            if event_type not in events.keys():
+                events[event_type] = []
+            events[event_type].append(drone_ids)
+
+        return State(sim_id, terminated, drone_states, events)

--- a/PyADRL/utils/ngw2d_client.py
+++ b/PyADRL/utils/ngw2d_client.py
@@ -3,10 +3,10 @@ from ..ngw.v1 import ngw2d_pb2, ngw2d_pb2_grpc
 
 
 class EventTypes:
-    CollisionEvent = 1
-    TargetReachedEvent = 2
-    OutOfBoundsEvent = 3
-    CaptureEvent = 4
+    CollisionEvent = "collision"
+    TargetReachedEvent = "target"
+    OutOfBoundsEvent = "out-of-bounds"
+    CaptureEvent = "capture"
 
 
 class DroneState:
@@ -72,7 +72,7 @@ class NGWClient:
 
     def Close(self, request: ngw2d_pb2.CloseRequest) -> None:
         close_response = self.stub.Close(request)
-        if close_response.has_error_message():
+        if close_response.HasField("error_message"):
             raise ValueError(
                 f"Close request responded with an error: {close_response.error_message}"
             )
@@ -115,5 +115,4 @@ class NGWClient:
             if event_type not in events.keys():
                 events[event_type] = []
             events[event_type].append(drone_ids)
-
         return State(sim_id, terminated, drone_states, events)

--- a/PyADRL/utils/ngw2d_client.py
+++ b/PyADRL/utils/ngw2d_client.py
@@ -3,10 +3,10 @@ from ..ngw.v1 import ngw2d_pb2, ngw2d_pb2_grpc
 
 
 class EventTypes:
-    CollisionEvent = "collision"
-    TargetReachedEvent = "target"
-    OutOfBoundsEvent = "out-of-bounds"
-    CaptureEvent = "capture"
+    CollisionEvent = "collision_event"
+    TargetReachedEvent = "target_reached_event"
+    OutOfBoundsEvent = "out_of_bounds_event"
+    CaptureEvent = "capture_event"
 
 
 class DroneState:
@@ -96,13 +96,13 @@ class NGWClient:
             drone_ids = []
             event_type = None
             match e.WhichOneof("event_oneof"):
-                case "target_reached_event":
+                case EventTypes.TargetReachedEvent as target_reached:
                     drone_ids = e.target_reached_event.drone_ids
-                    event_type = EventTypes.TargetReachedEvent
-                case "out_of_bounds_event":
+                    event_type = target_reached
+                case EventTypes.OutOfBoundsEvent as out_of_bounds:
                     drone_ids = e.out_of_bounds_event.drone_ids
-                    event_type = EventTypes.OutOfBoundsEvent
-                case "collision_event":
+                    event_type = out_of_bounds
+                case EventTypes.CollisionEvent:
                     drone_ids = e.collision_event.drone_ids
                     # Determine if it was a collision or a capture
                     has_evader = any(d in ids["evaders"] for d in drone_ids)
@@ -112,6 +112,8 @@ class NGWClient:
                         if has_evader and has_pursuer
                         else EventTypes.CollisionEvent
                     )
+                case _ as unkown_event:
+                    raise ValueError(f"Recieved unkown event type {unkown_event}")
             if event_type not in events.keys():
                 events[event_type] = []
             events[event_type].append(drone_ids)

--- a/PyADRL/utils/ngw2d_client.py
+++ b/PyADRL/utils/ngw2d_client.py
@@ -7,6 +7,7 @@ class EventTypes:
     TargetReachedEvent = "target_reached_event"
     OutOfBoundsEvent = "out_of_bounds_event"
     CaptureEvent = "capture_event"
+    PursuerEnteredTargetEvent = "pursuer_entered_target_event"
 
 
 class DroneState:
@@ -112,6 +113,9 @@ class NGWClient:
                         if has_evader and has_pursuer
                         else EventTypes.CollisionEvent
                     )
+                case EventTypes.PursuerEnteredTargetEvent as pusuer_in_target:
+                    drone_ids = e.pursuer_entered_target_event.drone_ids
+                    event_type = pusuer_in_target
                 case _ as unkown_event:
                     raise ValueError(f"Recieved unkown event type {unkown_event}")
             if event_type not in events.keys():


### PR DESCRIPTION
Fixes #58 
Changed so protos values don't bleed into the python code. The Gridworld reward function now gives rewards when evaders are captured and distance based rewards no longer consider destroyed drones. Also fixed so events actually match cases in the match statement.
This code hasn't been fully tested due to a bug in the simulation where terminated drones occur in events, but works fine if you skip any terminated agents when giving rewards.