### PR TITLE
Multiple callbacks for ppo config and fix observation space

### DIFF
--- a/PyADRL/envs/ngw_env.py
+++ b/PyADRL/envs/ngw_env.py
@@ -94,6 +94,9 @@ class NGWEnvironment(ParallelEnv):
             (norm_x, norm_y) = self.map_config.normalise_position(e.x, e.y)
             obs += [norm_x, norm_y]
 
+        # Include the fixed target position so the observation matches the declared space.
+        obs += [self.norm_target_x, self.norm_target_y]
+
         # Role bits, 1 for pursuer, 0 for evader
         obs += [1.0 for _ in self.drones[PURSUERS]] + [
             0.0 for _ in self.drones[EVADERS]

--- a/PyADRL/examples/trainables/alternate_training.py
+++ b/PyADRL/examples/trainables/alternate_training.py
@@ -111,7 +111,7 @@ def alternate_trainable(
     checkpoint_dir: str | None = None,
     n_stages: int = 4,
     iters_per_stage: int = 20,
-    callbacks: list[RLlibCallback] = [],
+    callbacks: list[type[RLlibCallback]] | None = None,
 ) -> None:  # type: ignore[type-arg]
     """Trainable function for Ray Tune.
 

--- a/PyADRL/examples/trainables/iterative_training.py
+++ b/PyADRL/examples/trainables/iterative_training.py
@@ -7,7 +7,7 @@ def iterative_trainable(
     config: dict,
     checkpoint_dir: str | None = None,
     iterations: int = 25,
-    callbacks: list[RLlibCallback] = [],
+    callbacks: list[type[RLlibCallback]] | None = None,
 ) -> None:  # type: ignore[type-arg]
     ppo_config = _build_ppo_config(
         lr=config["lr"],

--- a/PyADRL/utils/config_builder.py
+++ b/PyADRL/utils/config_builder.py
@@ -16,7 +16,7 @@ def _build_ppo_config(
     num_learners: int = 2,
     num_env_runners: int = 4,
     num_envs_per_env_runner: int = 5,
-    callbacks: list[RLlibCallback] = [],
+    callbacks: list[type[RLlibCallback]] | None = None,
 ) -> PPOConfig:
     """Build a PPOConfig with the given hyperparameters.
 
@@ -50,5 +50,5 @@ def _build_ppo_config(
             entropy_coeff=entropy_coeff,
         )
         .evaluation(evaluation_num_env_runners=0)
-        # .callbacks(callbacks_class = callbacks)
+        .callbacks(callbacks)
     )


### PR DESCRIPTION
Fixes #79 
Small fixes so multiple callbacks can be given when using the _build_ppo_config helper function and fixed the observation space so a simulation doesn't crash.
There are some errors with the heatmap callback that causes it to crash and should be fixed in another pull request.